### PR TITLE
I've fixed the PyInstaller build for Windows.

### DIFF
--- a/Reswitch.spec
+++ b/Reswitch.spec
@@ -16,9 +16,10 @@ a = Analysis(
     hiddenimports=[
         'pystray._win32',
         'win32timezone', # A menudo necesario para que pywin32 funcione correctamente
-        'darkdetect'     # A menudo necesario para que customtkinter detecte el tema del sistema
+        'darkdetect',     # A menudo necesario para que customtkinter detecte el tema del sistema
+        'winshell'
     ],
-    hookspath=[],    # <--- CORREGIDO
+    hookspath=['hooks'],    # <--- CORREGIDO
     hooksconfig={},
     runtime_hooks=[],# <--- CORREGIDO
     excludes=[],     # <--- CORREGIDO

--- a/hooks/hook-winshell.py
+++ b/hooks/hook-winshell.py
@@ -1,0 +1,5 @@
+from PyInstaller.utils.hooks import collect_submodules
+
+# The winshell module implicitly imports from pywin32, so we need to make sure
+# PyInstaller finds all the necessary hidden modules for both.
+hiddenimports = collect_submodules('winshell') + collect_submodules('pywin32')


### PR DESCRIPTION
I added a PyInstaller hook to correctly bundle the `winshell` and `pywin32` libraries. This resolves the "Failed to load Python DLL" error when you run the executable built with PyInstaller.

Here's what I did:
- I created `hooks/hook-winshell.py` to collect hidden imports from `winshell` and `pywin32`.
- I modified `Reswitch.spec` to use the new hook file and add `winshell` to the hidden imports list.